### PR TITLE
Hopefully fixed warning message for command cool-down

### DIFF
--- a/tamabot 0.3.0#1.py
+++ b/tamabot 0.3.0#1.py
@@ -40,15 +40,18 @@ async def on_command_error(ctx,error):
         await ctx.send("You are missing some perms bro xD")
     elif isinstance(error,commands.MissingRequiredArgument):
         await ctx.send("You are missing some required arguments dude lmao")
+    elif isinstance(error, commands.CommandOnCooldown):
+        cooldown_message = ('Wait right there, buster! ({:.1f}s remaining)').format(cooldown_message.retry_after)
+        await ctx.send(cooldown_message)
     else:
         raise error
     
 #bot command cooldown
-@bot.event
-async def on_command_cooldown(ctx,cooldown_message):
-    if isinstance(cooldown_message, commands.CommandOnCooldown):
-        cooldown_message = ('Wait right there, buster! ({:.1f}s remaining)').format(cooldown_message.retry_after)
-        await ctx.send(cooldown_message)
+# @bot.event
+# async def on_command_cooldown(ctx,cooldown_message):
+#     if isinstance(cooldown_message, commands.CommandOnCooldown):
+#         cooldown_message = ('Wait right there, buster! ({:.1f}s remaining)').format(cooldown_message.retry_after)
+#         await ctx.send(cooldown_message)
         
 #commands
 #the help command


### PR DESCRIPTION
Since you said the command cool-down was not working, I think it might be because it's entering `on_command_error` so I just moved your `isinstance(cooldown_message, commands.CommandOnCooldown)` to under `on_command_error` and commented `on_command_cooldown`.
Hopefully it works now,
Cheers!